### PR TITLE
Replace Twitter references with Mastodon link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ lang: en-US
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: https://ail-project.org # the base hostname & protocol for your site
 git_address: https://github.com/ail-project/
-twitter: https://twitter.com/ail_project
+mastodon: https://infosec.exchange/@ail_project
 #git_edit_address: https://github.com/ail-project/ail-website/blob/main
 
 # theme options from https://bootswatch.com/3/

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -31,7 +31,7 @@
                 </form>
                 <ul class="nav navbar-nav">
                     <li><a href="{{ site.git_address }}" aria-label="GitHub"><i class="fa fa-github" aria-hidden="true"></i></a></li>
-                    <li><a href="{{ site.twitter }}" aria-label="Twitter"><i class="fa fa-twitter" aria-hidden="true"></i></a></li>
+                    <li><a href="{{ site.mastodon }}" aria-label="Mastodon"><i class="fa fa-commenting" aria-hidden="true"></i></a></li>
                 </ul>
             </div>
         </div>

--- a/_posts/2024-09-18-AIL-v5.7.released.md
+++ b/_posts/2024-09-18-AIL-v5.7.released.md
@@ -131,6 +131,5 @@ Law enforcement agencies willing to discover and leverage the MISP-LEA platform 
 - **Website:** [ail-project.org](https://ail-project.org)
 - **GitHub:** [github.com/ail-project/ail-framework](https://github.com/ail-project/ail-framework)
 - **Mastodon** [@ail_project](https://infosec.exchange/@ail_project)
-- **Twitter/X/N*zi platform:** [@AIL_Project](https://twitter.com/AIL_Project)
 
 Thank you for your continued support. We look forward to your feedback!

--- a/_posts/2024-10-03-AIL-v5.8.released.md
+++ b/_posts/2024-10-03-AIL-v5.8.released.md
@@ -56,6 +56,5 @@ Law enforcement agencies willing to discover and leverage the MISP-LEA platform 
 - **Website:** [ail-project.org](https://ail-project.org)
 - **GitHub:** [github.com/ail-project/ail-framework](https://github.com/ail-project/ail-framework)
 - **Mastodon** [@ail_project](https://infosec.exchange/@ail_project)
-- **Twitter/X/N*zi platform:** [@AIL_Project](https://twitter.com/AIL_Project)
 
 Thank you for your continued support. We look forward to your feedback!

--- a/_posts/2024-10-18-AIL-v5.9.released.md
+++ b/_posts/2024-10-18-AIL-v5.9.released.md
@@ -62,6 +62,5 @@ Law enforcement agencies willing to discover and leverage the MISP-LEA platform 
 - **Website:** [ail-project.org](https://ail-project.org)
 - **GitHub:** [github.com/ail-project/ail-framework](https://github.com/ail-project/ail-framework)
 - **Mastodon** [@ail_project](https://infosec.exchange/@ail_project)
-- **Twitter/X/N*zi platform:** [@AIL_Project](https://twitter.com/AIL_Project)
 
 Thank you for your continued support. We look forward to your feedback!


### PR DESCRIPTION
### Motivation
- The site should stop referencing Twitter/X and instead point visitors to the project Mastodon account at `https://infosec.exchange/@ail_project`.
- Update navigation and post content so social links and labels reflect Mastodon consistently.

### Description
- Replaced the `twitter` site setting with `mastodon` and set it to `https://infosec.exchange/@ail_project` in `_config.yml`.
- Updated the top navigation in `_includes/topnav.html` to use `{{ site.mastodon }}`, changed the aria-label to `Mastodon`, and swapped the icon to `fa-commenting`.
- Removed legacy `Twitter/X` bullet lines from the release posts ` _posts/2024-09-18-AIL-v5.7.released.md`, `_posts/2024-10-03-AIL-v5.8.released.md`, and `_posts/2024-10-18-AIL-v5.9.released.md` so Mastodon is the single social reference in those sections.

### Testing
- Ran targeted searches with `rg` to find remaining `twitter`/`site.twitter` references and confirmed no matches remain in the edited files, which succeeded.
- Inspected edited files with `sed`/`nl` to verify the `mastodon` URL and navigation link changes, which succeeded.
- Attempted `bundle install` and `bundle exec jekyll build` to validate a local site build, but dependency installation failed with upstream gem fetch errors (`403 Forbidden` from rubygems.org), so a full site build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3afa9d5548324950b66617f527255)