### PR TITLE
Fix clipped page titles under expanded top navigation

### DIFF
--- a/_sass/_jekyll-doc-theme.scss
+++ b/_sass/_jekyll-doc-theme.scss
@@ -3,8 +3,9 @@ html {
     position: relative;
     min-height: 100%;
   }
-  body {
-    padding-top: $navbar-height + $navbar-margin-bottom;
+body {
+    // Keep page titles fully visible when the fixed top navigation wraps.
+    padding-top: $navbar-height + $navbar-margin-bottom + 32px;
     margin-bottom: 46px;
   }
   
@@ -28,7 +29,7 @@ html {
     // background-attachment: fixed;
     background-size: cover;
     background-position: center 36%;
-    margin-top: -37px;
+    margin-top: 0;
   }
   .navbar-container {
     font-size: 16px;


### PR DESCRIPTION
### Motivation
- The fixed top navigation can wrap to multiple lines and become taller, causing page titles and the homepage hero to be partially hidden beneath the nav.

### Description
- Increase the global top spacing by adding `+ 32px` to `padding-top` in `body` to ensure headers clear the fixed nav and set `.header-container` `margin-top` to `0` to avoid pulling the hero upward; changes made in `_sass/_jekyll-doc-theme.scss`.

### Testing
- Attempted `bundle exec jekyll build` to validate the site build but it failed because the `jekyll` executable was not available in the environment; the build could not be completed.
- Attempted `bundle install` to install dependencies but gem fetching failed with HTTP `403 Forbidden` from `rubygems.org`, so automated dependency installation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3b8fb76188324a77af27998d07fe5)