### PR TITLE
Remove search control from top navigation and tidy navbar actions

### DIFF
--- a/_includes/js_files.html
+++ b/_includes/js_files.html
@@ -1,8 +1,4 @@
-<script>
-  var baseurl = '{{ site.baseurl }}'
-</script>
 <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
 <script src="{{ "/assets/js/bootstrap.min.js" | relative_url }} "></script>
-<script src="{{ "/assets/js/typeahead.bundle.min.js" | relative_url }} "></script>
 
 <script src="{{ "/assets/js/main.js" | relative_url }} "></script>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -24,13 +24,7 @@
                 <a class="btn btn-primary navbar-latest-post" href="{{ site.posts[0].url | relative_url }}">
                     <i class="fa fa-bolt" aria-hidden="true"></i> Latest release
                 </a>
-                <form class="navbar-form navbar-left">
-                    <div class="form-group has-feedback">
-                        <input id="search-box" type="search" class="form-control" placeholder="Search...">
-                        <i class="fa fa-search form-control-feedback"></i>
-                    </div>
-                </form>
-                <ul class="nav navbar-nav">
+                <ul class="nav navbar-nav navbar-social-links">
                     <li><a href="{{ site.git_address }}" aria-label="GitHub"><i class="fa fa-github" aria-hidden="true"></i></a></li>
                     <li><a href="{{ site.mastodon }}" aria-label="Mastodon"><i class="fa fa-commenting" aria-hidden="true"></i></a></li>
                 </ul>

--- a/_sass/_jekyll-doc-theme.scss
+++ b/_sass/_jekyll-doc-theme.scss
@@ -166,15 +166,25 @@ body {
 .navbar-actions {
   display: flex;
   align-items: center;
+  gap: 8px;
 }
 
 .navbar-latest-post {
-  margin: 8px 12px 0 0;
+  margin: 8px 0 0;
   border-radius: 999px;
   font-weight: 600;
 
   .fa {
     margin-right: 6px;
+  }
+}
+
+.navbar-social-links {
+  margin: 0;
+
+  > li > a {
+    padding-left: 10px;
+    padding-right: 10px;
   }
 }
 
@@ -274,7 +284,11 @@ body {
 
   .navbar-latest-post {
     display: inline-block;
-    margin: 10px 0 8px 15px;
+    margin: 10px 0 6px 15px;
+  }
+
+  .navbar-social-links {
+    margin-left: 5px;
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,33 +1,8 @@
 $(function () {
-
-  function initSearchBox() {
-    var pages = new Bloodhound({
-      datumTokenizer: Bloodhound.tokenizers.obj.whitespace('title'),
-      // datumTokenizer: Bloodhound.tokenizers.whitespace,
-      queryTokenizer: Bloodhound.tokenizers.whitespace,
-
-      prefetch: baseurl + '/search.json'
-    });
-
-    $('#search-box').typeahead({
-      minLength: 0,
-      highlight: true
-    }, {
-        name: 'pages',
-        display: 'title',
-        source: pages
-      });
-
-    $('#search-box').bind('typeahead:select', function (ev, suggestion) {
-      window.location.href = suggestion.url;
-    });
-  }
-
   function styleContentToMD() {
     $('#markdown-content-container table').addClass('table');
     $('#markdown-content-container img').addClass('img-responsive');
   }
 
-  initSearchBox();
   styleContentToMD();
 });


### PR DESCRIPTION
### Motivation
- Simplify the top navigation by removing the search input and associated UI to make the header cleaner and less crowded.
- Remove unused search/typeahead runtime pieces to avoid loading unnecessary scripts and initialization logic.

### Description
- Removed the search form and input from the top nav and replaced the nav list wrapper with a dedicated `navbar-social-links` class for social icons (`_includes/topnav.html`).
- Removed the search initialization code from `assets/js/main.js` so no typeahead initialization runs when the search input is absent.
- Removed the inline `baseurl` JS snippet and the `typeahead.bundle.min.js` include from `_includes/js_files.html` since the search feature was removed.
- Adjusted navbar spacing and added styling for `navbar-social-links` (spacing, reduced CTA margins, and responsive tweaks) in `_sass/_jekyll-doc-theme.scss`.

### Testing
- Attempted `bundle exec jekyll build`, but the build could not run because the `jekyll` executable was not available in the environment (failed to execute).
- Attempted `bundle install` to prepare a local build environment, but fetching gems failed due to `403 Forbidden` responses from rubygems.org so dependencies could not be installed.
- Attempted a Playwright screenshot of a locally served site, but no local site was running due to the build/dependency limitations and the navigation capture failed with `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ff0420108324bd757248bf6c3001)