### PR TITLE
Reduce whitespace below fixed navigation bar

### DIFF
--- a/_sass/_jekyll-doc-theme.scss
+++ b/_sass/_jekyll-doc-theme.scss
@@ -5,7 +5,7 @@ html {
   }
 body {
     // Keep page titles fully visible when the fixed top navigation wraps.
-    padding-top: $navbar-height + $navbar-margin-bottom + 32px;
+    padding-top: $navbar-height + $navbar-margin-bottom;
     margin-bottom: 46px;
   }
   


### PR DESCRIPTION
### Motivation
- Remove unnecessary vertical gap between the fixed top navigation and main page content by eliminating an extra hardcoded offset.

### Description
- Update `_sass/_jekyll-doc-theme.scss` to change the `body` `padding-top` from `$navbar-height + $navbar-margin-bottom + 32px` to `$navbar-height + $navbar-margin-bottom` so content starts directly beneath the fixed navbar.

### Testing
- Verified the file change with `nl -ba _sass/_jekyll-doc-theme.scss` and attempted `bundle exec jekyll build` (failed because the `jekyll` executable is unavailable) and `bundle install` (failed due to remote gem fetch HTTP 403), so a full site build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b405d493e88324bc1f82016f92e3af)